### PR TITLE
feat(scripts): @ippoan/dev-plans-snapshot npm package 化 + per-flag SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish snapshot package
+
+on:
+  push:
+    tags:
+      - 'snapshot-pkg-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. snapshot-pkg-v0.1.0)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: scripts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@ippoan'
+
+      - name: Verify package.json version matches tag
+        if: startsWith(github.ref, 'refs/tags/snapshot-pkg-v')
+        run: |
+          PKG_VER=$(node -p "require('./package.json').version")
+          TAG_VER="${GITHUB_REF#refs/tags/snapshot-pkg-v}"
+          if [[ "$PKG_VER" != "$TAG_VER" ]]; then
+            echo "::error::package.json version ($PKG_VER) != tag ($TAG_VER)"
+            exit 1
+          fi
+          echo "Publishing @ippoan/dev-plans-snapshot@$PKG_VER"
+
+      - run: npm install --no-audit --no-fund
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -43,24 +43,42 @@ flowchart LR
 - `<scope>_<feature>` (例: `alc_kiosk_v2`, `auth_passkey_login`, `trouble_ai_summary`)
 - consumer repo のコードでは grep 可能なリテラルとして書く
 
-## consumer repo へのコピー方法
+## consumer repo の統合方法
+
+scripts は npm package `@ippoan/dev-plans-snapshot` として公開している (GHCR registry)。
 
 ```bash
-# rust-alc-api / auth-worker 等で
-mkdir -p scripts manifests .githooks
-cp /path/to/ippoan-dev-plans/scripts/{build-snapshot.js,check-snapshot.js,package.json} scripts/
-cp /path/to/ippoan-dev-plans/.githooks/pre-commit .githooks/
+# 1. 認証 (一度だけ): ~/.npmrc などに
+#    @ippoan:registry=https://npm.pkg.github.com
+#    //npm.pkg.github.com/:_authToken=<PAT with read:packages>
+#    consumer repo のルートに同内容の .npmrc を commit してもよい (token は env)
+
+# 2. consumer repo に install
+npm i -D @ippoan/dev-plans-snapshot
+
+# 3. dev-plans.config.js (consumer repo ルート)
+cat > dev-plans.config.js <<'EOF'
+export default {
+  scopeLabels: ['rust-alc-api', 'cross-repo'],          // この consumer に関係する plan のみ取得
+  grepPatterns: [/\bif_flag!\(\s*"([a-z][a-z0-9_]+)#([a-f0-9]{8})"/g],  // 2 capture group: name, sha
+  sourceDirs: ['src', 'crates'],                         // 言語/プロジェクト固有
+};
+EOF
+
+# 4. package.json に script
+#    "snapshot": "dev-plans-snapshot build",
+#    "snapshot:check": "dev-plans-snapshot check"
+
+# 5. 初期 snapshot 生成
+GITHUB_TOKEN=$(gh auth token) npm run snapshot
+git add manifests/production.snapshot.json
+
+# 6. pre-commit hook を有効化
+#    consumer repo の .githooks/pre-commit に snapshot:check を含めて
 git config core.hooksPath .githooks
-
-# 言語別に check-snapshot.js の grep パターンを編集
-# - Rust:     `if_flag!("xxx")` 形式
-# - Vue/TS:   `useFeatureFlag('xxx')` 形式
-
-# 初期 snapshot 生成
-GITHUB_TOKEN=$(gh auth token) node scripts/build-snapshot.js \
-  --owner ippoan --repo ippoan-dev-plans
-git add manifests/production.snapshot.json && git commit -m "chore: add initial snapshot"
 ```
+
+flag 識別子は `name#sha` ハイブリッド (sha = sha256(plan_id|id|source_issue) 先頭 8 桁)。同名 flag の事故を防ぎ、Issue rename / 番号変更を検知する。
 
 ## GitHub Project (kanban)
 
@@ -75,14 +93,14 @@ card の Stage 変更 → `stage:*` label 自動付与の同期は未実装。�
 
 新規 plan Issue を作成すると自動で Project に追加されるよう、Project の builtin workflow "Auto-add to project" を [Project の Workflows 設定](https://github.com/orgs/ippoan/projects/1/workflows) から有効化することを推奨 (UI 操作のみ可)。
 
-## Snapshot scripts
+## Snapshot scripts (`@ippoan/dev-plans-snapshot`)
 
-| script | 役割 |
+| CLI | 役割 |
 |---|---|
-| `scripts/build-snapshot.js` | GitHub API から `label:plan` の Issue を全 fetch → `manifests/production.snapshot.json` 生成 |
-| `scripts/check-snapshot.js` | snapshot の `issues_last_updated_at` と GitHub API 上の最新 updatedAt を比較 → drift 検出 / コードが参照する flag が snapshot に存在するか / removed flag が残ってないか確認 |
+| `dev-plans-snapshot build` | GitHub API から `label:plan` の Issue を fetch → `manifests/production.snapshot.json` 生成 (per-flag SHA 付き) |
+| `dev-plans-snapshot check` | drift 検出 + コードの `if_flag!("name#sha")` 参照が snapshot に存在するか + removed flag の残存確認 |
 
-両 script は **consumer repo にコピーして使う雛形**。詳細はファイル冒頭のコメント参照。
+リリースは `scripts/snapshot-pkg-v*` タグを push すると `.github/workflows/publish.yml` が GHCR registry へ npm publish する。
 
 ## Pre-commit hook
 

--- a/manifests/production.snapshot.json
+++ b/manifests/production.snapshot.json
@@ -1,9 +1,10 @@
 {
-  "generated_at": "2026-05-02T07:26:43.833Z",
-  "issues_last_updated_at": "2026-05-02T06:47:35Z",
+  "generated_at": "2026-05-02T08:28:05.497Z",
+  "issues_last_updated_at": "2026-05-02T08:20:37Z",
   "source": {
     "owner": "ippoan",
     "repo": "ippoan-dev-plans"
   },
+  "scope_filter": null,
   "flags": []
 }

--- a/scripts/build-snapshot.js
+++ b/scripts/build-snapshot.js
@@ -1,36 +1,23 @@
 #!/usr/bin/env node
 /**
- * build-snapshot.js
+ * Fetch plan issues from the central repo, extract YAML flag definitions
+ * from their bodies, attach a per-flag SHA, and write
+ * `<repo-root>/manifests/production.snapshot.json`.
  *
- * GitHub API から `label:plan` の Issue を全 fetch し、
- * 本文中の ```yaml ... ``` block を flag 定義として抽出して
- * `manifests/production.snapshot.json` を生成する。
+ * Config sources (precedence high→low):
+ *   1. env: SCOPE_LABELS, PLANS_OWNER, PLANS_REPO
+ *   2. <repo-root>/dev-plans.config.js (default export)
+ *   3. built-in defaults (owner=ippoan, repo=ippoan-dev-plans, no scope filter)
  *
- * Usage:
- *   GITHUB_TOKEN=xxx node build-snapshot.js [--owner <org>] [--repo <name>]
- *
- * これは「雛形」。consumer repo にコピーして使うときは:
- * - owner/repo を実際の plan 集約 repo (ippoan/ippoan-dev-plans) に固定
- * - manifests/ の出力先を必要に応じて変更
+ * Auth: GITHUB_TOKEN or GH_TOKEN env var.
  */
 
 import { Octokit } from "@octokit/rest";
 import { parse as parseYaml } from "yaml";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, "..");
-
-function parseArgs(argv) {
-  const out = { owner: "ippoan", repo: "ippoan-dev-plans" };
-  for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === "--owner") out.owner = argv[++i];
-    else if (argv[i] === "--repo") out.repo = argv[++i];
-  }
-  return out;
-}
+import crypto from "node:crypto";
+import { loadConfig, repoRoot } from "./config.js";
 
 function extractYamlBlock(body) {
   if (!body) return null;
@@ -46,7 +33,7 @@ function extractYamlBlock(body) {
 
 function pickStage(labels) {
   const stages = labels
-    .map((l) => l.name)
+    .map((l) => (typeof l === "string" ? l : l.name))
     .filter((n) => n.startsWith("stage:"))
     .map((n) => n.slice("stage:".length));
   return stages[0] ?? "proposed";
@@ -54,13 +41,28 @@ function pickStage(labels) {
 
 function pickScope(labels) {
   return labels
-    .map((l) => l.name)
+    .map((l) => (typeof l === "string" ? l : l.name))
     .filter((n) => n.startsWith("scope:"))
     .map((n) => n.slice("scope:".length));
 }
 
+function computeSha(planId, id, sourceIssue) {
+  return crypto
+    .createHash("sha256")
+    .update(`${planId}|${id}|${sourceIssue}`)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+function matchesScope(labels, scopeLabels) {
+  if (!scopeLabels || scopeLabels.length === 0) return true;
+  const wanted = new Set(scopeLabels.map((s) => `scope:${s}`));
+  return labels.some((l) => wanted.has(typeof l === "string" ? l : l.name));
+}
+
 async function main() {
-  const { owner, repo } = parseArgs(process.argv);
+  const config = await loadConfig();
+  const { owner, repo, scopeLabels } = config;
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     console.error("GITHUB_TOKEN or GH_TOKEN env var required");
@@ -76,9 +78,12 @@ async function main() {
     state: "all",
     per_page: 100,
   });
-  // PR を除外 (listForRepo は PR を含む)
-  const planIssues = issues.filter((i) => !i.pull_request);
-  console.error(`Found ${planIssues.length} plan issues`);
+  const planIssues = issues
+    .filter((i) => !i.pull_request)
+    .filter((i) => matchesScope(i.labels, scopeLabels));
+  console.error(
+    `Found ${planIssues.length} plan issues (scope filter: ${scopeLabels ? scopeLabels.join(",") : "none"})`,
+  );
 
   const flags = [];
   let lastUpdated = "1970-01-01T00:00:00Z";
@@ -87,13 +92,13 @@ async function main() {
     if (issue.updated_at > lastUpdated) lastUpdated = issue.updated_at;
 
     const def = extractYamlBlock(issue.body);
-    if (!def || typeof def !== "object" || !def.id) {
-      // yaml block 無し or id 欠如 → flag 定義としては記録しない (Issue 自体は last_updated に反映済)
-      continue;
-    }
+    if (!def || typeof def !== "object" || !def.id) continue;
+
+    const planId = def.plan_id ?? null;
     flags.push({
       id: def.id,
-      plan_id: def.plan_id ?? null,
+      sha: computeSha(planId, def.id, issue.number),
+      plan_id: planId,
       stage: pickStage(issue.labels),
       scope: pickScope(issue.labels),
       owner: def.owner ?? null,
@@ -105,19 +110,22 @@ async function main() {
     });
   }
 
-  flags.sort((a, b) => a.id.localeCompare(b.id));
+  flags.sort((a, b) => a.id.localeCompare(b.id) || a.sha.localeCompare(b.sha));
 
   const snapshot = {
     generated_at: new Date().toISOString(),
     issues_last_updated_at: lastUpdated,
     source: { owner, repo },
+    scope_filter: scopeLabels ?? null,
     flags,
   };
 
-  const outPath = path.join(REPO_ROOT, "manifests", "production.snapshot.json");
+  const outPath = path.join(repoRoot(), "manifests", "production.snapshot.json");
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, JSON.stringify(snapshot, null, 2) + "\n");
-  console.error(`Wrote ${outPath} (${flags.length} flags, last_updated=${lastUpdated})`);
+  console.error(
+    `Wrote ${outPath} (${flags.length} flags, last_updated=${lastUpdated})`,
+  );
 }
 
 main().catch((err) => {

--- a/scripts/check-snapshot.js
+++ b/scripts/check-snapshot.js
@@ -1,63 +1,42 @@
 #!/usr/bin/env node
 /**
- * check-snapshot.js
+ * Verify `<repo-root>/manifests/production.snapshot.json` against:
+ *   1. drift   — remote `issues_last_updated_at` (within scope filter) matches snapshot
+ *   2. refs    — every `if_flag!("name#sha")`-style ref in code resolves to a snapshot entry
+ *                with id===name && sha===sha
+ *   3. removed — refs whose snapshot entry has stage=="removed" are flagged
  *
- * 1. snapshot drift 検出: GitHub API 上の最新 updated_at と
- *    manifests/production.snapshot.json の issues_last_updated_at を比較
- * 2. flag 漏れ検出 (consumer repo 用): コードを grep して flag 名を抽出 →
- *    snapshot に存在しない flag があれば exit 1
- * 3. removed flag の参照検出: snapshot 内 stage:removed の flag を
- *    コードがまだ参照していたら exit 1
+ * Config sources: see `config.js`.
  *
- * Usage:
- *   GITHUB_TOKEN=xxx node check-snapshot.js [--owner X] [--repo Y] [--skip-grep]
+ * Auth: GITHUB_TOKEN or GH_TOKEN env var.
  *
- * これは「雛形」。consumer repo にコピーして使うときは:
- * - GREP_PATTERNS を実際の言語 (Rust の if_flag!() / Vue の useFeatureFlag()) に合わせて編集
- * - SOURCE_DIRS を src/ や app/ などに合わせて編集
+ * Args:
+ *   --skip-grep   skip steps 2/3 (drift only)
  */
 
 import { Octokit } from "@octokit/rest";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, "..");
-
-// consumer repo で編集する箇所 ↓↓↓
-const GREP_PATTERNS = [
-  // Rust: if_flag!("xxx") / flag_value!("xxx")
-  /\bif_flag!\(\s*"([a-z][a-z0-9_]+)"/g,
-  /\bflag_value!\(\s*"([a-z][a-z0-9_]+)"/g,
-  // Vue/TS: useFeatureFlag('xxx') / useFeatureFlag("xxx")
-  /\buseFeatureFlag\(\s*['"]([a-z][a-z0-9_]+)['"]/g,
-];
-const SOURCE_DIRS = ["src", "app", "crates", "server"]; // 存在するものだけ scan
-// ここまで ↑↑↑
-
-function parseArgs(argv) {
-  const out = { owner: "ippoan", repo: "ippoan-dev-plans", skipGrep: false };
-  for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === "--owner") out.owner = argv[++i];
-    else if (argv[i] === "--repo") out.repo = argv[++i];
-    else if (argv[i] === "--skip-grep") out.skipGrep = true;
-  }
-  return out;
-}
+import { loadConfig, repoRoot } from "./config.js";
 
 function readSnapshot() {
-  const p = path.join(REPO_ROOT, "manifests", "production.snapshot.json");
+  const p = path.join(repoRoot(), "manifests", "production.snapshot.json");
   if (!fs.existsSync(p)) {
     console.error(`snapshot not found: ${p}`);
-    console.error("run: node scripts/build-snapshot.js");
+    console.error("run: npx dev-plans-snapshot build");
     process.exit(1);
   }
   return JSON.parse(fs.readFileSync(p, "utf-8"));
 }
 
-async function fetchLastUpdated(octokit, owner, repo) {
+function matchesScope(labels, scopeLabels) {
+  if (!scopeLabels || scopeLabels.length === 0) return true;
+  const wanted = new Set(scopeLabels.map((s) => `scope:${s}`));
+  return labels.some((l) => wanted.has(typeof l === "string" ? l : l.name));
+}
+
+async function fetchLastUpdated(octokit, owner, repo, scopeLabels) {
   const issues = await octokit.paginate(octokit.issues.listForRepo, {
     owner,
     repo,
@@ -65,89 +44,123 @@ async function fetchLastUpdated(octokit, owner, repo) {
     state: "all",
     per_page: 100,
   });
-  const planIssues = issues.filter((i) => !i.pull_request);
+  const filtered = issues
+    .filter((i) => !i.pull_request)
+    .filter((i) => matchesScope(i.labels, scopeLabels));
   let last = "1970-01-01T00:00:00Z";
-  for (const i of planIssues) if (i.updated_at > last) last = i.updated_at;
+  for (const i of filtered) if (i.updated_at > last) last = i.updated_at;
   return last;
 }
 
-function grepFlagsFromCode() {
-  const found = new Set();
-  for (const dir of SOURCE_DIRS) {
-    const abs = path.join(REPO_ROOT, dir);
+function grepRefsFromCode(grepPatterns, sourceDirs) {
+  const refs = [];
+  const root = repoRoot();
+  for (const dir of sourceDirs) {
+    const abs = path.join(root, dir);
     if (!fs.existsSync(abs)) continue;
     let stdout;
     try {
-      // ripgrep 優先、なければ grep -r
-      stdout = execSync(`rg --no-heading --line-number --no-filename -- '' ${abs}`, {
-        stdio: ["ignore", "pipe", "ignore"],
-      }).toString();
+      stdout = execSync(
+        `rg --no-heading --line-number --no-filename -- '' ${JSON.stringify(abs)}`,
+        { stdio: ["ignore", "pipe", "ignore"] },
+      ).toString();
     } catch {
       try {
-        stdout = execSync(`grep -rh '' ${abs}`, {
+        stdout = execSync(`grep -rh '' ${JSON.stringify(abs)}`, {
           stdio: ["ignore", "pipe", "ignore"],
         }).toString();
       } catch {
         continue;
       }
     }
-    for (const re of GREP_PATTERNS) {
-      const r = new RegExp(re.source, re.flags);
+    for (const re of grepPatterns) {
+      const r = new RegExp(re.source, re.flags.includes("g") ? re.flags : re.flags + "g");
       let m;
-      while ((m = r.exec(stdout)) !== null) found.add(m[1]);
+      while ((m = r.exec(stdout)) !== null) {
+        refs.push({ name: m[1], sha: m[2] ?? null });
+      }
     }
   }
-  return found;
+  return refs;
 }
 
 async function main() {
-  const args = parseArgs(process.argv);
+  const args = process.argv.slice(2);
+  const skipGrep = args.includes("--skip-grep");
+
+  const config = await loadConfig();
   const snapshot = readSnapshot();
 
-  // 1. drift 検出
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
   if (!token) {
     console.error("GITHUB_TOKEN or GH_TOKEN env var required");
     process.exit(1);
   }
   const octokit = new Octokit({ auth: token });
-  const remoteLast = await fetchLastUpdated(octokit, args.owner, args.repo);
+
+  const remoteLast = await fetchLastUpdated(
+    octokit,
+    config.owner,
+    config.repo,
+    config.scopeLabels,
+  );
   if (remoteLast !== snapshot.issues_last_updated_at) {
     console.error(
-      `snapshot drift detected:\n  snapshot: ${snapshot.issues_last_updated_at}\n  remote:   ${remoteLast}`
+      `snapshot drift detected:\n  snapshot: ${snapshot.issues_last_updated_at}\n  remote:   ${remoteLast}`,
     );
-    console.error("rerun: node scripts/build-snapshot.js && git add manifests/");
+    console.error("rerun: npx dev-plans-snapshot build && git add manifests/");
     process.exit(1);
   }
   console.error(`OK: snapshot up-to-date (${remoteLast})`);
 
-  // 2. & 3. (consumer repo 用) コード grep
-  if (args.skipGrep) {
-    console.error("skipping code grep (--skip-grep)");
+  if (skipGrep || config.grepPatterns.length === 0) {
+    console.error("OK: code grep skipped (no patterns or --skip-grep)");
     return;
   }
 
-  const codeFlags = grepFlagsFromCode();
-  const snapshotIds = new Set(snapshot.flags.map((f) => f.id));
-  const removedIds = new Set(
-    snapshot.flags.filter((f) => f.stage === "removed").map((f) => f.id)
+  const refs = grepRefsFromCode(config.grepPatterns, config.sourceDirs);
+  const byName = new Map();
+  for (const f of snapshot.flags) {
+    if (!byName.has(f.id)) byName.set(f.id, []);
+    byName.get(f.id).push(f);
+  }
+  const removedKeys = new Set(
+    snapshot.flags.filter((f) => f.stage === "removed").map((f) => `${f.id}#${f.sha}`),
   );
 
-  const missing = [...codeFlags].filter((f) => !snapshotIds.has(f));
-  const stillReferencedRemoved = [...codeFlags].filter((f) => removedIds.has(f));
+  const errors = [];
+  for (const ref of refs) {
+    const entries = byName.get(ref.name);
+    const refLabel = ref.sha ? `${ref.name}#${ref.sha}` : ref.name;
+    if (!entries) {
+      errors.push(
+        `unregistered flag: ${refLabel} (no plan issue with id="${ref.name}" found in snapshot)`,
+      );
+      continue;
+    }
+    if (ref.sha === null) {
+      continue;
+    }
+    const matched = entries.find((e) => e.sha === ref.sha);
+    if (!matched) {
+      const known = entries.map((e) => e.sha).join(", ");
+      errors.push(
+        `stale sha: ${refLabel} — known sha(s) for "${ref.name}": [${known}]. regenerate snapshot or update code reference.`,
+      );
+      continue;
+    }
+    if (removedKeys.has(`${ref.name}#${ref.sha}`)) {
+      errors.push(`removed flag still referenced: ${refLabel} (stage:removed)`);
+    }
+  }
 
-  if (missing.length > 0) {
-    console.error(`flags referenced in code but missing from snapshot:`);
-    missing.forEach((f) => console.error(`  - ${f}`));
+  if (errors.length > 0) {
+    console.error("flag reference check failed:");
+    for (const e of errors) console.error(`  - ${e}`);
     process.exit(1);
   }
-  if (stillReferencedRemoved.length > 0) {
-    console.error(`flags marked stage:removed but still referenced in code:`);
-    stillReferencedRemoved.forEach((f) => console.error(`  - ${f}`));
-    process.exit(1);
-  }
 
-  console.error(`OK: ${codeFlags.size} flag references match snapshot`);
+  console.error(`OK: ${refs.length} flag references match snapshot`);
 }
 
 main().catch((err) => {

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cmd = process.argv[2];
+
+if (cmd === "build") {
+  await import(path.join(here, "build-snapshot.js"));
+} else if (cmd === "check") {
+  await import(path.join(here, "check-snapshot.js"));
+} else {
+  console.error("Usage: dev-plans-snapshot <build|check> [--skip-grep]");
+  console.error("");
+  console.error("  build  Fetch plan issues and write manifests/production.snapshot.json");
+  console.error("  check  Validate snapshot against remote + verify code 'if_flag!(\"name#sha\")' refs");
+  process.exit(2);
+}

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,58 @@
+import path from "node:path";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import { execSync } from "node:child_process";
+
+const DEFAULTS = {
+  owner: "ippoan",
+  repo: "ippoan-dev-plans",
+  scopeLabels: null,
+  grepPatterns: [],
+  sourceDirs: ["src", "app", "crates", "server", "components", "composables", "pages"],
+};
+
+export function repoRoot() {
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+export async function loadConfig() {
+  const root = repoRoot();
+  const candidates = [
+    path.join(root, "dev-plans.config.js"),
+    path.join(root, "dev-plans.config.mjs"),
+  ];
+
+  let userConfig = {};
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      const mod = await import(pathToFileURL(p).href);
+      userConfig = mod.default ?? mod;
+      break;
+    }
+  }
+
+  if (process.env.SCOPE_LABELS) {
+    userConfig = {
+      ...userConfig,
+      scopeLabels: process.env.SCOPE_LABELS.split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    };
+  }
+  if (process.env.PLANS_OWNER) userConfig = { ...userConfig, owner: process.env.PLANS_OWNER };
+  if (process.env.PLANS_REPO) userConfig = { ...userConfig, repo: process.env.PLANS_REPO };
+
+  const merged = { ...DEFAULTS, ...userConfig };
+  merged.grepPatterns = (merged.grepPatterns ?? []).map((p) =>
+    p instanceof RegExp ? p : new RegExp(p, "g"),
+  );
+  return merged;
+}

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,15 +1,19 @@
 {
-  "name": "ippoan-dev-plans-scripts",
+  "name": "@ippoan/dev-plans-snapshot",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ippoan-dev-plans-scripts",
+      "name": "@ippoan/dev-plans-snapshot",
       "version": "0.1.0",
+      "license": "UNLICENSED",
       "dependencies": {
         "@octokit/rest": "^21.0.2",
         "yaml": "^2.6.1"
+      },
+      "bin": {
+        "dev-plans-snapshot": "cli.js"
       }
     },
     "node_modules/@octokit/auth-token": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,9 +1,17 @@
 {
-  "name": "ippoan-dev-plans-scripts",
+  "name": "@ippoan/dev-plans-snapshot",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
-  "description": "Snapshot build/check scripts for ippoan-dev-plans (and consumer repos to copy)",
+  "description": "Snapshot build/check tool for ippoan plan-as-issue management. Fetches GitHub Issues labeled 'plan' from a central repo, generates manifests/production.snapshot.json with per-flag SHA, and verifies code references against the snapshot.",
+  "bin": {
+    "dev-plans-snapshot": "./cli.js"
+  },
+  "files": [
+    "build-snapshot.js",
+    "check-snapshot.js",
+    "cli.js",
+    "config.js"
+  ],
   "scripts": {
     "build": "node build-snapshot.js",
     "check": "node check-snapshot.js"
@@ -11,5 +19,16 @@
   "dependencies": {
     "@octokit/rest": "^21.0.2",
     "yaml": "^2.6.1"
-  }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ippoan/ippoan-dev-plans.git",
+    "directory": "scripts"
+  },
+  "homepage": "https://github.com/ippoan/ippoan-dev-plans#readme",
+  "license": "UNLICENSED"
 }


### PR DESCRIPTION
## Summary

Refs #8 (cross-repo split of #2). 既存 `scripts/build-snapshot.js` / `scripts/check-snapshot.js` を `@ippoan/dev-plans-snapshot` GHCR npm package として publish できる構成に再編。consumer repo (rust-alc-api 他) は verbatim copy ではなく `npm i -D` + `npx dev-plans-snapshot` で取り込む。

### 主な変更

- `scripts/package.json` — name `@ippoan/dev-plans-snapshot`、`bin: dev-plans-snapshot`、`publishConfig.registry: https://npm.pkg.github.com`、private 解除
- `scripts/cli.js` — `dev-plans-snapshot <build|check>` ディスパッチ
- `scripts/config.js` — consumer ルートの `dev-plans.config.js` をロード (`scopeLabels` / `grepPatterns` / `sourceDirs` / `owner` / `repo`)、env override (`SCOPE_LABELS` / `PLANS_OWNER` / `PLANS_REPO`)、`git rev-parse` でリポジトリルート自己解決
- `build-snapshot.js` — 各 flag に `sha = sha256("plan_id|id|source_issue").hex.slice(0,8)` を付与、scope label フィルタ、`(id, sha)` で安定 sort
- `check-snapshot.js` — GREP_PATTERN は 2 capture group (name, sha) を想定。`name+sha 一致のみ OK` / `sha 不一致は stale ref` / `未登録 / removed 残存` を従来どおり検知
- `.github/workflows/publish.yml` 新規 — タグ `snapshot-pkg-v*` push で GHCR npm publish

### 後方互換

ippoan-dev-plans 自身の `.githooks/pre-commit` は `node scripts/build-snapshot.js` を直接呼ぶ既存挙動のまま動作 (config 無しなら scope filter なしの全 plan Issue 対象)。

### ローカル smoke 結果

- `node scripts/cli.js build` → 9 plan issues fetched, 0 flags (まだ YAML block 持つ Issue が無い)
- `SCOPE_LABELS=rust-alc-api,cross-repo node scripts/cli.js build` → 6 issues に絞れる
- `node scripts/cli.js check` → drift OK / grep skipped (no patterns)
- `/tmp` の throwaway repo に if_flag!(\"ghost_flag#deadbeef\") を仕込み → unregistered flag で exit 1

## Test plan

- [ ] CI: PR check 緑
- [ ] merge 後に snapshot-pkg-v0.1.0 タグ push → publish.yml 成功 → @ippoan/dev-plans-snapshot@0.1.0 が GHCR registry に出る
- [ ] 別 repo (rust-alc-api worktree) で npm i -D @ippoan/dev-plans-snapshot + npx dev-plans-snapshot check 動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)